### PR TITLE
Add full News module: admin CRUD and public newspaper-style display

### DIFF
--- a/backend/src/main/java/com/researchers_conicet/service/NewsService.java
+++ b/backend/src/main/java/com/researchers_conicet/service/NewsService.java
@@ -206,6 +206,7 @@ public class NewsService {
         }
     }
 
+
     /**
      * Maps News entity to NewsResponseDTO
      */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import AdminExperiments from "./pages/Admin/Experiments/AdminExperiments";
 import AddAnalogy  from "./pages/Admin/Analogies/AddAnalogy";
 import EditAnalogy from "./pages/Admin/Analogies/EditAnalogy";
 import AdminEmails from "./pages/Admin/Emails/AdminEmails";
+import AdminNews from "./pages/Admin/News/AdminNews";
 import AnalogiesDetail from './pages/Inbox/AnalogiesDetail';
 
 // Protected Route Component
@@ -111,6 +112,14 @@ const App = () => {
           element={
             <ProtectedRoute>
               <AdminEmails />
+            </ProtectedRoute>
+          } 
+        />
+        <Route 
+          path="/admin/news" 
+          element={
+            <ProtectedRoute>
+              <AdminNews />
             </ProtectedRoute>
           } 
         />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,9 @@ import AnalogiesDetail from './pages/Inbox/AnalogiesDetail';
 import AddNews from "./pages/Admin/News/AddNews";
 import EditNews from "./pages/Admin/News/EditNews";
 
+// Nuevas importaciones para noticias públicas
+import NewsSection from "./pages/News/NewsSection";
+import NewsDetail from "./pages/News/NewsDetail";
 
 // Protected Route Component
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
@@ -43,6 +46,10 @@ const App = () => {
         <Route path="/participation" element={<Participation />} />
         <Route path="/inbox" element={<Inbox />} />
         <Route path="/analogies/:id" element={<AnalogiesDetail />} />
+
+        {/* Noticias públicas */}
+        <Route path="/news" element={<NewsSection />} />
+        <Route path="/news/:id" element={<NewsDetail />} />
 
         {/* Admin Routes */}
         <Route path="/admin/login" element={<Login />} />
@@ -86,7 +93,7 @@ const App = () => {
             </ProtectedRoute>
           } 
         />
-         <Route 
+        <Route 
           path="/admin/analogies/add" 
           element={
             <ProtectedRoute>
@@ -94,7 +101,7 @@ const App = () => {
             </ProtectedRoute>
           } 
         />
-         <Route 
+        <Route 
           path="/admin/analogies/edit/:id" 
           element={
             <ProtectedRoute>
@@ -142,7 +149,6 @@ const App = () => {
             </ProtectedRoute>
           } 
         />
-
       </Routes>
     </Router>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,9 @@ import EditAnalogy from "./pages/Admin/Analogies/EditAnalogy";
 import AdminEmails from "./pages/Admin/Emails/AdminEmails";
 import AdminNews from "./pages/Admin/News/AdminNews";
 import AnalogiesDetail from './pages/Inbox/AnalogiesDetail';
+import AddNews from "./pages/Admin/News/AddNews";
+import EditNews from "./pages/Admin/News/EditNews";
+
 
 // Protected Route Component
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
@@ -123,6 +126,23 @@ const App = () => {
             </ProtectedRoute>
           } 
         />
+        <Route 
+          path="/admin/news/add" 
+          element={
+            <ProtectedRoute>
+              <AddNews />
+            </ProtectedRoute>
+          } 
+        />
+        <Route 
+          path="/admin/news/edit/:id" 
+          element={
+            <ProtectedRoute>
+              <EditNews />
+            </ProtectedRoute>
+          } 
+        />
+
       </Routes>
     </Router>
   );

--- a/frontend/src/api/news.ts
+++ b/frontend/src/api/news.ts
@@ -1,0 +1,163 @@
+import axios from "axios";
+import {
+  News,
+  NewsDTO,
+  ApiResponse,
+  PaginatedResponse,
+} from "../types";
+
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:8080/api";
+const NEWS_PATH = "/news";
+
+/**
+ * Fetch all news with pagination
+ */
+export const getAllNews = async (
+  page = 0,
+  size = 10
+): Promise<PaginatedResponse<News[]>> => {
+  try {
+    const response = await axios.get<PaginatedResponse<News[]>>(
+      `${API_BASE_URL}${NEWS_PATH}`,
+      {
+        params: {
+          page,
+          size,
+          sort: "createdAt",
+          direction: "DESC",
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching news:", error);
+    throw error;
+  }
+};
+
+/**
+ * Fetch a single news article by ID
+ */
+export const getNewsById = async (id: number): Promise<News> => {
+  try {
+    const response = await axios.get<News>(
+      `${API_BASE_URL}${NEWS_PATH}/${id}`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching news by ID:", error);
+    throw error;
+  }
+};
+
+/**
+ * Create a new news article
+ */
+export const createNews = async (
+  data: NewsDTO
+): Promise<ApiResponse<News>> => {
+  try {
+    const response = await axios.post<ApiResponse<News>>(
+      `${API_BASE_URL}${NEWS_PATH}`,
+      data,
+      {
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error creating news:", error);
+    throw error;
+  }
+};
+
+/**
+ * Update an existing news article
+ */
+export const updateNews = async (
+  id: number,
+  data: NewsDTO
+): Promise<ApiResponse<News>> => {
+  try {
+    const response = await axios.put<ApiResponse<News>>(
+      `${API_BASE_URL}${NEWS_PATH}/${id}`,
+      data,
+      {
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error updating news:", error);
+    throw error;
+  }
+};
+
+/**
+ * Delete a news article
+ */
+export const deleteNews = async (id: number): Promise<void> => {
+  try {
+    await axios.delete(`${API_BASE_URL}${NEWS_PATH}/${id}`);
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 500) {
+        throw new Error("Internal server error while deleting news.");
+      } else if (error.response?.status === 404) {
+        throw new Error("News article not found.");
+      }
+    }
+    throw new Error("Failed to delete news");
+  }
+};
+
+/**
+ * Search news by title
+ */
+export const searchNewsByTitle = async (
+  query: string
+): Promise<ApiResponse<News[]>> => {
+  try {
+    const response = await axios.get<ApiResponse<News[]>>(
+      `${API_BASE_URL}${NEWS_PATH}/search/title`,
+      {
+        params: { query },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error searching news by title:", error);
+    throw error;
+  }
+};
+
+/**
+ * Global search (title, authors, etc.)
+ */
+export const searchNewsEverywhere = async (
+  query: string
+): Promise<ApiResponse<News[]>> => {
+  try {
+    const response = await axios.get<ApiResponse<News[]>>(
+      `${API_BASE_URL}${NEWS_PATH}/search`,
+      {
+        params: { query },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error in global news search:", error);
+    throw error;
+  }
+};
+
+export default {
+  getAllNews,
+  getNewsById,
+  createNews,
+  updateNews,
+  deleteNews,
+  searchNewsByTitle,
+  searchNewsEverywhere,
+};

--- a/frontend/src/components/common/Navbar.tsx
+++ b/frontend/src/components/common/Navbar.tsx
@@ -12,6 +12,7 @@ const Navbar: FC = () => {
     { id: 'lab', title: 'Research Lines', path: '/lab' },
     { id: 'members', title: 'Members', path: '/members' },
     { id: 'publications', title: 'Publications', path: '/publications' },
+    { id: 'news', title: 'News', path: '/news' },
     { id: 'participation', title: 'Experiment Participations', path: '/participation' },
     { id: 'inbox', title: 'Analogy Inbox', path: '/inbox' }
   ];

--- a/frontend/src/components/news/NewsForm.tsx
+++ b/frontend/src/components/news/NewsForm.tsx
@@ -298,8 +298,19 @@ const NewsForm: FC<NewsFormProps> = ({
                     src={src}
                     alt={`media-${i}`}
                     className={selectedPreviewIndex === i ? 'selected-preview' : ''}
-                    onClick={() => setSelectedPreviewIndex(i)}
-                  />
+                    onClick={() => {
+                      if (selectedPreviewIndex === i) {
+                        // Deselecciona si ya está seleccionada
+                        setSelectedPreviewIndex(null);
+                        setFormData(prev => ({ ...prev, previewImage: '' }));
+                      } else {
+                        // Selecciona nueva preview
+                        setSelectedPreviewIndex(i);
+                        setFormData(prev => ({ ...prev, previewImage: formData.mediaLinks[i]?.url || '' }));
+                      }
+                    }}
+/>
+
                 )}
                 <button type="button" className="remove-tag" onClick={() => handleRemoveMedia(i)}>×</button>
               </div>

--- a/frontend/src/components/news/NewsForm.tsx
+++ b/frontend/src/components/news/NewsForm.tsx
@@ -1,0 +1,295 @@
+import { FC, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { uploadFile } from '../../api/firebaseUploader';
+import './styles/NewsForm.css';
+
+interface NewsFormProps {
+  onSubmit: (data: NewsDTO, id?: number) => Promise<void>;
+  initialData?: News;
+  isSubmitting?: boolean;
+  error?: string | null;
+  isEditing?: boolean;
+}
+
+interface MediaLink {
+  url: string;
+  mediaType: string;
+}
+
+interface NewsDTO {
+  title: string;
+  content: string;
+  authors: string[];
+  links: string[];
+  mediaLinks: MediaLink[];
+  previewImage: string;
+}
+
+interface News {
+  id: number;
+  title: string;
+  content: string;
+  authors: string[];
+  links: string[];
+  mediaLinks: MediaLink[];
+  previewImage: string;
+}
+
+const NewsForm: FC<NewsFormProps> = ({
+  onSubmit,
+  initialData,
+  isSubmitting = false,
+  error: externalError = null,
+  isEditing = false
+}) => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState<NewsDTO>({
+    title: '',
+    content: '',
+    authors: [],
+    links: [],
+    mediaLinks: [],
+    previewImage: ''
+  });
+
+  const [mediaFiles, setMediaFiles] = useState<File[]>([]);
+  const [mediaPreviews, setMediaPreviews] = useState<string[]>([]);
+  const [mediaTypes, setMediaTypes] = useState<string[]>([]);
+  const [selectedPreviewIndex, setSelectedPreviewIndex] = useState<number | null>(null);
+  const [linkInput, setLinkInput] = useState('');
+  const [authorInput, setAuthorInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [internalError, setInternalError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData({
+        title: initialData.title,
+        content: initialData.content || '',
+        authors: initialData.authors || [],
+        links: initialData.links || [],
+        mediaLinks: initialData.mediaLinks || [],
+        previewImage: initialData.previewImage || ''
+      });
+      setMediaPreviews(initialData.mediaLinks.map(link => link.url));
+      setMediaTypes(initialData.mediaLinks.map(link => link.mediaType));
+      const previewIdx = initialData.mediaLinks.findIndex(m => m.url === initialData.previewImage);
+      setSelectedPreviewIndex(previewIdx !== -1 ? previewIdx : null);
+    }
+  }, [initialData]);
+
+  const handleAddLink = () => {
+    if (linkInput.trim()) {
+      setFormData(prev => ({
+        ...prev,
+        links: [...prev.links, linkInput.trim()]
+      }));
+      setLinkInput('');
+    }
+  };
+
+  const handleAddAuthor = () => {
+    if (authorInput.trim()) {
+      setFormData(prev => ({
+        ...prev,
+        authors: [...prev.authors, authorInput.trim()]
+      }));
+      setAuthorInput('');
+    }
+  };
+
+  const handleRemoveMedia = (index: number) => {
+    const newFiles = [...mediaFiles];
+    const newPreviews = [...mediaPreviews];
+    const newTypes = [...mediaTypes];
+    const newMediaLinks = [...formData.mediaLinks];
+
+    newFiles.splice(index, 1);
+    newPreviews.splice(index, 1);
+    newTypes.splice(index, 1);
+    newMediaLinks.splice(index, 1);
+
+    setMediaFiles(newFiles);
+    setMediaPreviews(newPreviews);
+    setMediaTypes(newTypes);
+    setFormData(prev => ({
+      ...prev,
+      mediaLinks: newMediaLinks
+    }));
+
+    if (selectedPreviewIndex === index) {
+      setSelectedPreviewIndex(null);
+      setFormData(prev => ({ ...prev, previewImage: '' }));
+    } else if (selectedPreviewIndex && selectedPreviewIndex > index) {
+      setSelectedPreviewIndex(prev => (prev ?? 0) - 1);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setInternalError(null);
+
+    if (!formData.title.trim() || formData.authors.length === 0) {
+      setInternalError('Title and at least one author are required.');
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const uploadedLinks: MediaLink[] = await Promise.all(
+        mediaFiles.map(async (file) => ({
+          url: await uploadFile(file),
+          mediaType: file.type.startsWith('video') ? 'video' : 'image'
+        }))
+      );
+
+      const allMediaLinks = [...formData.mediaLinks, ...uploadedLinks];
+      const previewImageUrl = selectedPreviewIndex !== null
+        ? allMediaLinks[selectedPreviewIndex]?.url || ''
+        : formData.previewImage;
+
+      await onSubmit(
+        {
+          ...formData,
+          mediaLinks: allMediaLinks,
+          previewImage: previewImageUrl
+        },
+        initialData?.id
+      );
+    } catch (err) {
+      console.error(err);
+      setInternalError(err instanceof Error ? err.message : 'An error occurred.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="news-form">
+      {(externalError || internalError) && (
+        <div className="error-message">{externalError || internalError}</div>
+      )}
+
+      <div className="form-group">
+        <label>Title *</label>
+        <input
+          type="text"
+          value={formData.title}
+          onChange={e => setFormData({ ...formData, title: e.target.value })}
+          placeholder="Enter news title"
+        />
+      </div>
+
+      <div className="form-group">
+        <label>Content</label>
+        <textarea
+          value={formData.content}
+          onChange={e => setFormData({ ...formData, content: e.target.value })}
+          placeholder="Enter news content"
+        />
+      </div>
+
+      <div className="form-group">
+        <label>Authors *</label>
+        <div className="input-with-button">
+          <input
+            type="text"
+            value={authorInput}
+            onChange={(e) => setAuthorInput(e.target.value)}
+            placeholder="Add author"
+          />
+          <button type="button" onClick={handleAddAuthor}>Add</button>
+        </div>
+        <div className="tags">
+          {formData.authors.map((author, idx) => (
+            <span key={idx} className="tag">
+              {author}
+              <button type="button" onClick={() =>
+                setFormData(prev => ({
+                  ...prev,
+                  authors: prev.authors.filter((_, i) => i !== idx)
+                }))
+              }>×</button>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label>Links</label>
+        <div className="input-with-button">
+          <input
+            type="url"
+            value={linkInput}
+            onChange={e => setLinkInput(e.target.value)}
+            placeholder="https://"
+          />
+          <button type="button" onClick={handleAddLink}>Add</button>
+        </div>
+        <div className="tags">
+          {formData.links.map((link, idx) => (
+            <span key={idx} className="tag">
+              {link}
+              <button type="button" onClick={() =>
+                setFormData(prev => ({
+                  ...prev,
+                  links: prev.links.filter((_, i) => i !== idx)
+                }))
+              }>×</button>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label>Media (images/videos) *</label>
+        <input
+          type="file"
+          accept="image/*,video/*"
+          multiple
+          onChange={(e) => {
+            const files = Array.from(e.target.files || []);
+            const previews = files.map(file => URL.createObjectURL(file));
+            const types = files.map(file => file.type.startsWith('video') ? 'video' : 'image');
+
+            setMediaFiles(prev => [...prev, ...files]);
+            setMediaPreviews(prev => [...prev, ...previews]);
+            setMediaTypes(prev => [...prev, ...types]);
+          }}
+        />
+        <div className="media-preview-grid">
+          {mediaPreviews.map((src, i) => (
+            <div key={i} className="media-preview">
+              {mediaTypes[i] === 'video' ? (
+                <video src={src} controls />
+              ) : (
+                <img
+                  src={src}
+                  alt={`media-${i}`}
+                  className={selectedPreviewIndex === i ? 'selected-preview' : ''}
+                  onClick={() => setSelectedPreviewIndex(i)}
+                />
+              )}
+              <button type="button" className="remove-tag" onClick={() => handleRemoveMedia(i)}>×</button>
+            </div>
+          ))}
+        </div>
+        {selectedPreviewIndex !== null && (
+          <div className="help-text">Selected image will be used as preview</div>
+        )}
+      </div>
+
+      <div className="form-actions">
+        <button type="submit" className="submit-btn" disabled={isSubmitting || isLoading}>
+          {isSubmitting ? 'Submitting...' : (isEditing ? 'Update News' : 'Submit News')}
+        </button>
+        <button type="button" onClick={() => navigate(-1)} className="cancel-btn" disabled={isSubmitting || isLoading}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default NewsForm;

--- a/frontend/src/components/news/styles/NewsForm.css
+++ b/frontend/src/components/news/styles/NewsForm.css
@@ -1,0 +1,236 @@
+.news-form {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: var(--spacing-lg);
+  background-color: var(--background-color);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+.error-message {
+  background-color: var(--error-light);
+  color: var(--error-color);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-md);
+  margin-bottom: var(--spacing-lg);
+  font-size: var(--font-size-base);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.form-group {
+  margin-bottom: var(--spacing-lg);
+}
+
+.form-group label {
+  display: block;
+  color: var(--text-color);
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  margin-bottom: var(--spacing-sm);
+}
+
+.form-group textarea,
+.form-group input {
+  width: 100%;
+  padding: var(--spacing-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-md);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
+  transition: all var(--transition-fast);
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+.form-group textarea {
+  min-height: 150px;
+  resize: vertical;
+}
+
+.form-group textarea:focus,
+.form-group input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px var(--primary-light);
+}
+
+.input-with-button {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+.input-with-button input {
+  flex: 1;
+}
+
+.input-with-button button {
+  background-color: var(--primary-color);
+  color: var(--background-color);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border: none;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-size: var(--font-size-base);
+  min-width: 100px;
+}
+
+.input-with-button button:hover:not(:disabled) {
+  background-color: var(--primary-dark);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.input-with-button button:disabled {
+  background-color: var(--disabled-color);
+  color: var(--disabled-text);
+  cursor: not-allowed;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.tag {
+  background-color: var(--primary-light);
+  color: var(--primary-dark);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--border-radius-full);
+  font-size: var(--font-size-small);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.remove-tag {
+  background: none;
+  border: none;
+  color: var(--primary-dark);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 50%;
+  transition: all var(--transition-fast);
+  font-size: var(--font-size-base);
+  line-height: 1;
+}
+
+.remove-tag:hover:not(:disabled) {
+  background-color: var(--primary-dark);
+  color: var(--background-color);
+}
+
+.remove-tag:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.form-actions {
+  display: flex;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-xl);
+}
+
+.submit-btn,
+.cancel-btn {
+  padding: var(--spacing-md) var(--spacing-lg);
+  border: none;
+  border-radius: var(--border-radius-md);
+  font-size: var(--font-size-base);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  flex: 1;
+  max-width: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+}
+
+.submit-btn {
+  background-color: var(--success-color);
+  color: var(--background-color);
+}
+
+.submit-btn:hover:not(:disabled) {
+  background-color: var(--success-color);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.cancel-btn {
+  background-color: var(--text-light);
+  color: var(--background-color);
+}
+
+.cancel-btn:hover:not(:disabled) {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.required {
+  color: var(--error-color);
+  margin-left: var(--spacing-xs);
+}
+
+.help-text {
+  font-size: var(--font-size-tiny);
+  color: var(--text-light);
+  margin-top: var(--spacing-xs);
+}
+
+.media-preview-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.media-preview {
+  width: 240px;
+  height: 180px;
+  position: relative;
+}
+
+.media-preview video,
+.media-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+}
+
+.media-preview img.selected-preview {
+  outline: 3px solid var(--success-color);
+  box-shadow: 0 0 0 2px var(--success-color);
+}
+
+.media-preview .remove-tag {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background-color: var(--error-color);
+  color: var(--background-color);
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .news-form {
+    padding: var(--spacing-md);
+  }
+
+  .form-actions {
+    flex-direction: column;
+  }
+
+  .submit-btn,
+  .cancel-btn {
+    max-width: 100%;
+  }
+}

--- a/frontend/src/components/news/styles/NewsForm.css
+++ b/frontend/src/components/news/styles/NewsForm.css
@@ -19,6 +19,12 @@
   gap: var(--spacing-sm);
 }
 
+.validation-message {
+  font-size: var(--font-size-small);
+  color: var(--error-color);
+  margin-top: var(--spacing-xs);
+}
+
 .form-group {
   margin-bottom: var(--spacing-lg);
 }
@@ -44,6 +50,12 @@
   color: var(--text-color);
 }
 
+.form-group textarea.error,
+.form-group input.error {
+  border-color: var(--error-color);
+  background-color: var(--error-light);
+}
+
 .form-group textarea {
   min-height: 150px;
   resize: vertical;
@@ -54,6 +66,22 @@
   outline: none;
   border-color: var(--primary-color);
   box-shadow: 0 0 0 3px var(--primary-light);
+}
+
+.required {
+  color: var(--error-color);
+  margin-left: var(--spacing-xs);
+}
+
+.optional {
+  font-size: var(--font-size-small);
+  color: var(--text-light);
+}
+
+.help-text {
+  font-size: var(--font-size-tiny);
+  color: var(--text-light);
+  margin-top: var(--spacing-xs);
 }
 
 .input-with-button {
@@ -173,15 +201,38 @@
   transform: translateY(-1px);
 }
 
-.required {
-  color: var(--error-color);
-  margin-left: var(--spacing-xs);
+.author-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
 }
 
-.help-text {
-  font-size: var(--font-size-tiny);
-  color: var(--text-light);
-  margin-top: var(--spacing-xs);
+.author-option {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--border-color);
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.author-option img {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--border-radius-full);
+  border: 2px solid var(--primary-light);
+  object-fit: cover;
+}
+
+.author-option.selected {
+  background-color: var(--primary-light);
+  border-color: var(--primary-color);
+}
+
+.author-option:hover {
+  background-color: var(--hover-color);
 }
 
 .media-preview-grid {
@@ -219,16 +270,46 @@
   color: var(--background-color);
 }
 
-/* Responsive design */
+.loading-spinner {
+  width: 80px;
+  height: 80px;
+  border: 6px solid var(--background-color);
+  border-top: 6px solid #3498db;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.loading-spinner-wrapper {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 9999;
+}
+
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 9998;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (max-width: 768px) {
   .news-form {
     padding: var(--spacing-md);
   }
-
   .form-actions {
     flex-direction: column;
   }
-
   .submit-btn,
   .cancel-btn {
     max-width: 100%;

--- a/frontend/src/pages/Admin/Dashboard.tsx
+++ b/frontend/src/pages/Admin/Dashboard.tsx
@@ -23,25 +23,31 @@ const Dashboard = () => {
             onClick={() => navigate('/admin/publications')} 
             className="dashboard-button"
           >
-            Publications
+            <span>Publications</span>
           </button>
           <button 
             onClick={() => navigate('/admin/analogies')} 
             className="dashboard-button"
           >
-            Analogies
+            <span>Analogies</span>
           </button>
           <button 
             onClick={() => navigate('/admin/experiments')} 
             className="dashboard-button"
           >
-            Experiments
+            <span>Experiments</span>
+          </button>
+          <button 
+            onClick={() => navigate('/admin/news')} 
+            className="dashboard-button"
+          >
+            <span>News</span>
           </button>
           <button 
             onClick={() => navigate('/admin/emails')} 
             className="dashboard-button"
           >
-            Email Management
+            <span>Email Management</span>
           </button>
         </div>
       </main>

--- a/frontend/src/pages/Admin/News/AddNews.tsx
+++ b/frontend/src/pages/Admin/News/AddNews.tsx
@@ -1,0 +1,57 @@
+import { FC, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import NewsForm from '../../../components/news/NewsForm';
+import { createNews } from '../../../api/news';
+import { NewsDTO } from '../../../types';
+import './styles/AddNews.css';
+
+const AddNews: FC = () => {
+  const navigate = useNavigate();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (data: NewsDTO, id?: number) => {
+    try {
+      setIsSubmitting(true);
+      setError(null);
+
+      if (id) {
+        console.log('Potential update for ID:', id);
+      }
+
+      await createNews(data);
+      navigate('/admin/news');
+    } catch (error) {
+      console.error('Error creating news:', error);
+      setError(error instanceof Error ? error.message : 'Failed to create news');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="add-news-page">
+      <header className="add-news-header">
+        <button
+          onClick={() => navigate('/admin/news')}
+          className="add-news-back-btn"
+        >
+          Back to News
+        </button>
+        <h1 className="add-news-title">Add News Article</h1>
+      </header>
+      <main className="add-news-content">
+        <div className="add-news-form-wrapper">
+          <NewsForm
+            onSubmit={handleSubmit}
+            isSubmitting={isSubmitting}
+            error={error}
+            isEditing={false}
+          />
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default AddNews;

--- a/frontend/src/pages/Admin/News/AdminNews.tsx
+++ b/frontend/src/pages/Admin/News/AdminNews.tsx
@@ -1,0 +1,148 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
+
+import { getAllNews, deleteNews } from '../../../api/news';
+import { News } from '../../../types';
+import './styles/AdminNews.css';
+
+const AdminNews: React.FC = () => {
+  const navigate = useNavigate();
+
+  const [newsList, setNewsList] = useState<News[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadNews = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await getAllNews(0, 100);
+      
+      const extractNews = (data: any): News[] => {
+        if (Array.isArray(data)) return data;
+        if (Array.isArray(data?.content)) return data.content;
+        if (Array.isArray(data?.data)) return data.data;
+        if (Array.isArray(data?.data?.content)) return data.data.content;
+        return [];
+        };
+
+        setNewsList(extractNews(response));
+
+
+    } catch (err) {
+      console.error('Error loading news:', err);
+      setError('Failed to load news. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadNews();
+  }, [loadNews]);
+
+  const handleDelete = useCallback(async (id: number) => {
+    try {
+      await deleteNews(id);
+      setNewsList(prev => prev.filter(item => item.id !== id));
+      setDeleteConfirm(null);
+    } catch (err) {
+      console.error('Error deleting news:', err);
+      setError('Failed to delete news. Please try again.');
+    }
+  }, []);
+
+  const renderNewsList = () => {
+    if (loading) return <div className="loading">Loading news...</div>;
+    if (error) return <div className="error-message">{error}</div>;
+    if (newsList.length === 0) return <div className="no-news">No news articles available</div>;
+
+    return newsList.map(news => (
+      <NewsListItem
+        key={news.id}
+        news={news}
+        deleteConfirm={deleteConfirm}
+        onEditClick={() => navigate(`/admin/news/edit/${news.id}`)}
+        onDeleteConfirmToggle={() =>
+          setDeleteConfirm(deleteConfirm === news.id ? null : news.id)
+        }
+        onDeleteConfirm={() => handleDelete(news.id)}
+      />
+    ));
+  };
+
+  return (
+    <div className="admin-page-container">
+      <header className="admin-page-header">
+        <button onClick={() => navigate('/admin/dashboard')} className="back-button">
+          Back to Dashboard
+        </button>
+        <h1>News Management</h1>
+        <button onClick={() => navigate('/admin/news/add')} className="add-button">
+          Add New Article
+        </button>
+      </header>
+      <main className="admin-page-content">
+        <div className="admin-news-list">
+          {renderNewsList()}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+interface NewsListItemProps {
+  news: News;
+  deleteConfirm: number | null;
+  onEditClick: () => void;
+  onDeleteConfirmToggle: () => void;
+  onDeleteConfirm: () => void;
+}
+
+const NewsListItem: React.FC<NewsListItemProps> = React.memo(({
+  news,
+  deleteConfirm,
+  onEditClick,
+  onDeleteConfirmToggle,
+  onDeleteConfirm
+}) => (
+  <div className="admin-news-card">
+    <div className="news-info">
+      <p className="news-admin-title">{news.title}</p>
+      <p className="news-authors">
+        Authors: {news.authors?.join(', ') || 'N/A'}
+      </p>
+      {news.links?.length > 0 && (
+        <p className="news-links">
+          Links: {news.links.length}
+        </p>
+      )}
+    </div>
+    <div className="news-actions">
+      <button onClick={onEditClick} className="action-button" title="Edit">
+        <FontAwesomeIcon icon={faEdit} />
+      </button>
+      {deleteConfirm === news.id ? (
+        <div className="delete-confirm">
+          <p>Are you sure?</p>
+          <button onClick={onDeleteConfirm} className="confirm-button">Yes</button>
+          <button onClick={onDeleteConfirmToggle} className="cancel-button">No</button>
+        </div>
+      ) : (
+        <button
+          onClick={onDeleteConfirmToggle}
+          className="action-button delete"
+          title="Delete"
+        >
+          <FontAwesomeIcon icon={faTrash} />
+        </button>
+      )}
+    </div>
+  </div>
+));
+
+export default AdminNews;

--- a/frontend/src/pages/Admin/News/EditNews.tsx
+++ b/frontend/src/pages/Admin/News/EditNews.tsx
@@ -1,0 +1,82 @@
+import { FC, useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import NewsForm from '../../../components/news/NewsForm';
+import { getNewsById, updateNews } from '../../../api/news';
+import { News, NewsDTO } from '../../../types';
+import './styles/EditNews.css';
+
+const EditNews: FC = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [newsItem, setNewsItem] = useState<News | null>(null);
+
+  useEffect(() => {
+    const loadNews = async () => {
+      try {
+        if (!id) return;
+        const data = await getNewsById(parseInt(id));
+        setNewsItem(data);
+      } catch (error) {
+        console.error('Error loading news:', error);
+        setError('Failed to load news item');
+      }
+    };
+
+    loadNews();
+  }, [id]);
+
+  const handleSubmit = async (data: NewsDTO, _id?: number) => {
+    try {
+      setIsSubmitting(true);
+      setError(null);
+
+      if (!id) return;
+      await updateNews(parseInt(id), data);
+      navigate('/admin/news');
+    } catch (error) {
+      console.error('Error updating news:', error);
+      setError(error instanceof Error ? error.message : 'Failed to update news');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!newsItem) {
+    return (
+      <div className="edit-news-page">
+        <div className="edit-news-loading-wrapper">
+          <div className="edit-news-loading-text">Loading news...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="edit-news-page">
+      <header className="edit-news-header">
+        <button 
+          onClick={() => navigate('/admin/news')} 
+          className="edit-news-back-btn"
+        >
+          Back to News
+        </button>
+        <h1 className="edit-news-title">Edit News</h1>
+      </header>
+      <main className="edit-news-content">
+        <div className="edit-news-form-wrapper">
+          <NewsForm 
+            initialData={newsItem}
+            onSubmit={handleSubmit}
+            isSubmitting={isSubmitting}
+            error={error}
+            isEditing={true}
+          />
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default EditNews;

--- a/frontend/src/pages/Admin/News/styles/AddNews.css
+++ b/frontend/src/pages/Admin/News/styles/AddNews.css
@@ -1,0 +1,146 @@
+.add-news-page {
+  min-height: 100vh;
+  background-color: var(--secondary-background);
+  font-family: var(--font-family);
+}
+
+.add-news-header {
+  background-color: var(--background-color);
+  padding: var(--spacing-md) var(--spacing-lg);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+  position: relative;
+  min-height: 64px;
+}
+
+.add-news-title {
+  margin: 0;
+  color: var(--text-color);
+  font-size: var(--font-size-xl);
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.add-news-back-btn {
+  background-color: var(--primary-color);
+  color: var(--background-color);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: none;
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-size: var(--font-size-base);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  z-index: 1;
+  min-width: 120px;
+  justify-content: center;
+}
+
+.add-news-back-btn:hover {
+  background-color: var(--primary-dark);
+  transform: translateX(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.add-news-back-btn:active {
+  transform: translateX(0);
+}
+
+.add-news-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.add-news-form-wrapper {
+  width: 100%;
+  max-width: 800px;
+  background-color: var(--background-color);
+  padding: var(--spacing-lg);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+/* Error styles */
+.add-news-error {
+  background-color: var(--error-light);
+  color: var(--error-color);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-md);
+  margin-bottom: var(--spacing-lg);
+  width: 100%;
+  text-align: center;
+  font-size: var(--font-size-base);
+}
+
+/* Success styles */
+.add-news-success {
+  background-color: var(--success-light);
+  color: var(--success-color);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-md);
+  margin-bottom: var(--spacing-lg);
+  width: 100%;
+  text-align: center;
+  font-size: var(--font-size-base);
+}
+
+/* Responsive adjustments */
+@media (max-width: 1024px) {
+  .add-news-content {
+    padding: var(--spacing-md);
+  }
+
+  .add-news-form-wrapper {
+    padding: var(--spacing-md);
+  }
+}
+
+@media (max-width: 768px) {
+  .add-news-header {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    min-height: auto;
+    padding-top: var(--spacing-lg);
+    padding-bottom: var(--spacing-lg);
+  }
+
+  .add-news-title {
+    position: static;
+    transform: none;
+    margin: var(--spacing-sm) 0;
+    font-size: var(--font-size-large);
+  }
+
+  .add-news-back-btn {
+    width: 100%;
+    max-width: 300px;
+  }
+}
+
+@media (max-width: 480px) {
+  .add-news-content {
+    padding: var(--spacing-sm);
+  }
+
+  .add-news-form-wrapper {
+    padding: var(--spacing-sm);
+  }
+
+  .add-news-title {
+    font-size: var(--font-size-base);
+  }
+}

--- a/frontend/src/pages/Admin/News/styles/AdminNews.css
+++ b/frontend/src/pages/Admin/News/styles/AdminNews.css
@@ -1,0 +1,61 @@
+@import '../../styles/AdminCommonStyles.css';
+
+.admin-news-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+}
+
+.admin-news-card {
+    background-color: var(--background-color);
+    border-radius: var(--border-radius-md);
+    padding: var(--spacing-lg);
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--spacing-lg);
+    transition: all var(--transition-fast);
+}
+
+.admin-news-card:hover {
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+
+.news-info {
+    flex: 1;
+    max-width: 70%;
+}
+
+.news-admin-title {
+    color: var(--text-color);
+    margin-bottom: var(--spacing-sm);
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-base);
+    font-weight: bold;
+}
+
+.news-authors {
+    color: var(--text-light);
+    font-size: var(--font-size-small);
+    margin-bottom: var(--spacing-xs);
+}
+
+.news-links {
+    color: var(--text-light);
+    font-size: var(--font-size-small);
+}
+
+.no-news {
+    text-align: center;
+    color: var(--text-light);
+    padding: var(--spacing-xl);
+    font-size: var(--font-size-large);
+}
+
+.news-actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    align-items: center;
+}

--- a/frontend/src/pages/Admin/News/styles/EditNews.css
+++ b/frontend/src/pages/Admin/News/styles/EditNews.css
@@ -1,0 +1,77 @@
+.edit-news-page {
+  min-height: 100vh;
+  background-color: var(--secondary-background);
+  font-family: var(--font-family);
+}
+
+.edit-news-header {
+  background-color: var(--background-color);
+  padding: var(--spacing-md) var(--spacing-lg);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+  position: relative;
+  min-height: 64px;
+}
+
+.edit-news-title {
+  margin: 0;
+  color: var(--text-color);
+  font-size: var(--font-size-xl);
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.edit-news-back-btn {
+  background-color: var(--text-light);
+  color: var(--background-color);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border: none;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-size: var(--font-size-base);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  min-width: 120px;
+}
+
+.edit-news-back-btn:hover {
+  background-color: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+.edit-news-content {
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.edit-news-form-wrapper {
+  width: 100%;
+  max-width: 800px;
+  background-color: var(--background-color);
+  padding: var(--spacing-lg);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+.edit-news-loading-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.edit-news-loading-text {
+  font-size: var(--font-size-large);
+  color: var(--text-light);
+}

--- a/frontend/src/pages/Admin/styles/Dashboard.css
+++ b/frontend/src/pages/Admin/styles/Dashboard.css
@@ -1,12 +1,10 @@
 /* pages/Admin/Dashboard.css */
 
-/* Main container for the dashboard */
 .dashboard-container {
   min-height: 100vh;
   background-color: var(--secondary-background);
 }
 
-/* Header styling with flex layout */
 .dashboard-header {
   background-color: var(--background-color);
   padding: var(--spacing-md) var(--spacing-lg);
@@ -16,14 +14,12 @@
   align-items: center;
 }
 
-/* Header title styling */
 .dashboard-header h1 {
   color: var(--text-color);
   font-size: var(--font-size-xl);
   margin: 0;
 }
 
-/* Logout button with error color scheme */
 .logout-button {
   background-color: var(--error-color);
   color: var(--background-color);
@@ -34,79 +30,88 @@
   transition: background-color var(--transition-fast);
 }
 
-/* Hover effect for logout button */
 .logout-button:hover {
   background-color: var(--error-color);
   opacity: 0.9;
 }
 
-/* Main content area with max width and centered */
 .dashboard-content {
   padding: var(--spacing-lg);
   max-width: var(--max-width);
   margin: 0 auto;
 }
 
-/* Container for dashboard action buttons */
 .dashboard-buttons {
   display: flex;
-  flex-direction: row;
+  flex-wrap: wrap;
   justify-content: center;
-  gap: var(--spacing-xl); /* Large spacing between buttons */
+  align-items: stretch;
+  gap: var(--spacing-xl);
   margin: var(--spacing-xl) auto;
-  width: 100%; /* Full width container */
+  width: 100%;
   padding: 0 var(--spacing-lg);
 }
 
-/* Individual dashboard button styling */
 .dashboard-button {
   background-color: var(--primary-color);
   color: var(--background-color);
-  padding: var(--spacing-xl) var(--spacing-lg); /* Large padding for bigger buttons */
   border: none;
   border-radius: var(--border-radius-lg);
-  font-size: var(--font-size-xl); /* Larger text */
+  font-size: var(--font-size-xl);
+  font-weight: bold;
+  text-align: center;
   cursor: pointer;
   transition: all var(--transition-fast);
-  flex: 1; /* Equal width distribution */
-  max-width: 300px; /* Maximum button width */
-  min-height: 200px; /* Fixed minimum height */
+  box-shadow: var(--shadow-md);
+  padding: var(--spacing-xl);
+
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: bold;
-  box-shadow: var(--shadow-md);
+
+  flex: 1 1 0;
+  min-height: 200px;
+  max-width: 300px;
 }
 
-/* Hover effect for dashboard buttons */
+.dashboard-button span {
+  display: block;
+  padding: 0 var(--spacing-sm);
+  line-height: 1.4;
+  white-space: normal;
+  word-break: normal;
+  overflow-wrap: break-word;
+  hyphens: auto;
+}
+
 .dashboard-button:hover {
   background-color: var(--primary-dark);
-  transform: translateY(-5px); /* Slight lift effect */
+  transform: translateY(-5px);
   box-shadow: var(--shadow-lg);
 }
 
-/* Responsive design for tablets */
+/* Responsive: tablet */
 @media (max-width: 1024px) {
   .dashboard-buttons {
-      gap: var(--spacing-lg); /* Reduced spacing for smaller screens */
+    gap: var(--spacing-lg);
   }
 
   .dashboard-button {
-      padding: var(--spacing-lg);
-      min-height: 150px; /* Smaller height for tablets */
+    padding: var(--spacing-lg);
+    min-height: 160px;
   }
 }
 
-/* Responsive design for mobile devices */
+/* Responsive: mobile */
 @media (max-width: 768px) {
   .dashboard-buttons {
-      flex-direction: column; /* Stack buttons vertically */
-      align-items: center;
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .dashboard-button {
-      width: 100%;
-      max-width: 400px; /* Wider buttons on mobile */
-      min-height: 120px; /* Reduced height for mobile */
+    width: 100%;
+    max-width: 400px;
+    min-height: 140px;
   }
 }

--- a/frontend/src/pages/News/NewsDetail.tsx
+++ b/frontend/src/pages/News/NewsDetail.tsx
@@ -1,0 +1,219 @@
+// src/pages/news/NewsDetail.tsx
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import MainLayout from "../../layouts/MainLayout";
+import { News } from "../../types";
+import { getNewsById } from "../../api/news";
+import { authors as authorsList } from "../../api/authors";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowLeft, faNewspaper } from "@fortawesome/free-solid-svg-icons";
+import axios from "axios";
+import FullScreenImageModal from "../../components/common/FullScreenImageModal";
+import "./styles/NewsDetail.css";
+
+const NewsDetail: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [news, setNews] = useState<News | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [fullscreenMedia, setFullscreenMedia] = useState<string | null>(null);
+  const [isImageLoading, setIsImageLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        if (!id) throw new Error("Invalid news ID");
+
+        const newsResponse = await getNewsById(Number(id));
+        if (!newsResponse) throw new Error("News not found");
+
+        setNews(newsResponse);
+      } catch (error) {
+        console.error("Error fetching news:", error);
+        if (axios.isAxiosError(error)) {
+          setError(
+            error.response?.data?.message ||
+              error.message ||
+              "Failed to load news"
+          );
+        } else {
+          setError("An unexpected error occurred");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  const getAuthorData = (authorName: string) => {
+    return authorsList.find(
+      (author) => `${author.firstName} ${author.lastName}` === authorName
+    );
+  };
+
+  const openMediaFullscreen = (mediaUrl: string) => {
+    setIsImageLoading(true);
+    setFullscreenMedia(mediaUrl);
+  };
+
+  const closeFullscreenMedia = () => {
+    setFullscreenMedia(null);
+    setIsImageLoading(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="loading-container">
+        <div className="spinner"></div>
+        <p>Loading news...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="error-container">
+        <p>{error}</p>
+        <button onClick={() => navigate("/")}>Go Back</button>
+      </div>
+    );
+  }
+
+  if (!news) {
+    return (
+      <div className="error-container">
+        <p>No news found</p>
+        <button onClick={() => navigate("/")}>Go Back</button>
+      </div>
+    );
+  }
+
+  const galleryMedia = news.mediaLinks.filter(
+    (m) => m.url !== news.previewImage
+  );
+
+  return (
+    <MainLayout>
+      {fullscreenMedia && (
+        <FullScreenImageModal
+          imageUrl={fullscreenMedia}
+          isLoading={isImageLoading}
+          onClose={closeFullscreenMedia}
+          onImageLoad={() => setIsImageLoading(false)}
+        />
+      )}
+
+      <div className="news-detail-page">
+        <button className="back-button" onClick={() => navigate(-1)}>
+          <FontAwesomeIcon icon={faArrowLeft} /> Back
+        </button>
+
+        {/* Authors & date */}
+        <div className="news-meta">
+          <div className="news-authors">
+            {news.authors.map((authorName) => {
+              const author = getAuthorData(authorName);
+              return author ? (
+                <div key={authorName} className="author-profile">
+                  <img
+                    src={author.imageUrl}
+                    alt={authorName}
+                    className="author-profile-image"
+                  />
+                  <span className="author-name">{authorName}</span>
+                </div>
+              ) : (
+                <span key={authorName} className="author-tag">
+                  {authorName}
+                </span>
+              );
+            })}
+          </div>
+          <p className="creation-date">
+            {new Date(news.createdAt).toLocaleDateString("en-US", {
+              day: "numeric",
+              month: "long",
+              year: "numeric",
+            })}
+          </p>
+        </div>
+
+        {/* Cover */}
+        <div className="news-cover">
+          {news.previewImage ? (
+            <img
+              src={news.previewImage}
+              alt={news.title}
+              className="news-cover-image"
+            />
+          ) : (
+            <div className="news-placeholder-cover">
+              <FontAwesomeIcon icon={faNewspaper} className="news-placeholder-icon" />
+            </div>
+          )}
+          <div className="news-cover-overlay">
+            <h1 className="news-title">{news.title}</h1>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="news-content">{news.content}</div>
+
+        {/* Gallery */}
+        {galleryMedia.length > 0 && (
+        <div className="news-media-gallery">
+            {galleryMedia.map((media, index) => (
+            <div
+                key={index}
+                className="media-item"
+                onClick={
+                media.mediaType.includes("video")
+                    ? undefined // No abrir modal para videos
+                    : () => openMediaFullscreen(media.url)
+                }
+                style={{
+                cursor: media.mediaType.includes("video") ? "default" : "pointer"
+                }}
+            >
+                {media.mediaType.includes("video") ? (
+                <video controls>
+                    <source src={media.url} />
+                </video>
+                ) : (
+                <img src={media.url} alt={`media-${index}`} />
+                )}
+            </div>
+            ))}
+        </div>
+        )}
+
+
+        {/* Links */}
+        {news.links.length > 0 && (
+          <div className="news-links">
+            <h3>Related Links</h3>
+            {news.links.map((link, index) => (
+              <a
+                key={index}
+                href={link}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {link}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </MainLayout>
+  );
+};
+
+export default NewsDetail;

--- a/frontend/src/pages/News/NewsSection.tsx
+++ b/frontend/src/pages/News/NewsSection.tsx
@@ -1,0 +1,128 @@
+import { FC, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import MainLayout from "../../layouts/MainLayout";
+import { News, PaginatedResponse } from "../../types";
+import { getAllNews } from "../../api/news";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSearch, faNewspaper } from "@fortawesome/free-solid-svg-icons";
+import { authors as authorsList } from "../../api/authors";
+import "./styles/NewsSection.css";
+
+const NewsSection: FC = () => {
+  const navigate = useNavigate();
+  const [newsList, setNewsList] = useState<News[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const loadNews = async () => {
+    try {
+      setLoading(true);
+      const response: PaginatedResponse<News> = await getAllNews(0, 20);
+      setNewsList(response.content || []);
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError("Error loading news");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadNews();
+  }, []);
+
+  const getAuthorData = (authorName: string) => {
+    return authorsList.find(
+      (author) => `${author.firstName} ${author.lastName}` === authorName
+    );
+  };
+
+  const filteredNews = newsList.filter(
+    (news) =>
+      news.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      news.authors?.some((author) =>
+        author.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+  );
+
+  return (
+    <MainLayout>
+      <div className="news-section-container">
+        <div className="news-section-header">
+          <h1>News</h1>
+          <div className="news-section-actions">
+            <div className="news-section-search-container">
+              <input
+                type="text"
+                placeholder="Search news..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="news-section-search-input"
+              />
+              <FontAwesomeIcon icon={faSearch} className="news-section-search-icon" />
+            </div>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="news-section-loading">Loading news...</div>
+        ) : error ? (
+          <div className="news-section-error">{error}</div>
+        ) : (
+          <div className="news-section-list">
+            {filteredNews.map((news) => (
+              <div
+                key={news.id}
+                className="news-section-item"
+                onClick={() => navigate(`/news/${news.id}`)}
+              >
+                <div className="news-section-authors-bar">
+                  {news.authors?.map((name) => {
+                    const author = getAuthorData(name);
+                    return author ? (
+                      <img
+                        key={name}
+                        src={author.imageUrl}
+                        alt={name}
+                        className="news-section-author-avatar"
+                      />
+                    ) : (
+                      <div key={name} className="news-section-author-placeholder">
+                        {name[0]}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="news-section-image-wrapper">
+                  {news.previewImage ? (
+                    <img
+                      src={news.previewImage}
+                      alt={news.title}
+                      className="news-section-image"
+                    />
+                  ) : (
+                    <div className="news-section-placeholder">
+                      <FontAwesomeIcon
+                        icon={faNewspaper}
+                        className="news-section-placeholder-icon"
+                      />
+                    </div>
+                  )}
+
+                  <div className="news-section-title-overlay">
+                    <h2>{news.title}</h2>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </MainLayout>
+  );
+};
+
+export default NewsSection;

--- a/frontend/src/pages/News/styles/NewsDetail.css
+++ b/frontend/src/pages/News/styles/NewsDetail.css
@@ -1,0 +1,174 @@
+.news-detail-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--spacing-xl) var(--spacing-lg);
+}
+
+.back-button {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: var(--font-size-base);
+  cursor: pointer;
+  margin-bottom: var(--spacing-lg);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.back-button:hover {
+  color: var(--primary-color);
+}
+
+.news-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-lg);
+  flex-wrap: wrap;
+}
+
+.news-authors {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.author-profile {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.author-profile-image {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.author-tag {
+  background-color: var(--primary-light);
+  color: var(--primary-dark);
+  padding: 4px 10px;
+  border-radius: var(--border-radius-full);
+  font-size: 0.9rem;
+}
+
+.creation-date {
+  font-size: var(--font-size-small);
+  color: var(--text-light);
+}
+
+.news-cover {
+  position: relative;
+  width: 100%;
+  height: 450px;
+  overflow: hidden;
+  border-radius: var(--border-radius-lg);
+  margin-bottom: var(--spacing-lg);
+}
+
+.news-cover-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.news-cover:hover .news-cover-image {
+  transform: scale(1.05);
+}
+
+.news-placeholder-cover {
+  width: 100%;
+  height: 100%;
+  background: #b3b3b3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.news-placeholder-icon {
+  font-size: 5rem;
+  color: white;
+  opacity: 0.8;
+}
+
+.news-cover-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: var(--spacing-xl) var(--spacing-lg);
+  background: linear-gradient(180deg, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0.85) 100%);
+}
+
+.news-title {
+  color: white;
+  font-size: clamp(2rem, 3vw, 3rem);
+  font-weight: 900;
+  margin: 0;
+  text-shadow: 0px 3px 8px rgba(0,0,0,0.7);
+}
+
+.news-content {
+  font-size: var(--font-size-lg);
+  color: var(--text-color);
+  line-height: 1.8;
+  margin-bottom: var(--spacing-xl);
+}
+
+.news-media-gallery {
+  display: flex;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-lg);
+}
+
+.media-item {
+  cursor: pointer;
+  flex: 1 1 calc(33.33% - var(--spacing-md));
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+  border: 2px solid var(--primary-color);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.media-item img,
+.media-item video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  max-height: 350px;
+}
+
+.media-item:hover {
+  transform: scale(1.05);
+  transition: transform 0.3s ease;
+}
+
+.news-links {
+  margin-top: var(--spacing-lg);
+}
+
+.news-links a {
+  display: block;
+  color: var(--primary-dark);
+  font-weight: bold;
+  text-decoration: none;
+  margin-bottom: var(--spacing-xs);
+}
+
+.news-links a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .news-cover {
+    height: 300px;
+  }
+  .media-item {
+    flex: 1 1 100%;
+  }
+}

--- a/frontend/src/pages/News/styles/NewsDetail.css
+++ b/frontend/src/pages/News/styles/NewsDetail.css
@@ -133,6 +133,8 @@
   overflow: hidden;
   border: 2px solid var(--primary-color);
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  aspect-ratio: 4 / 3;
+  display: flex;
 }
 
 .media-item img,
@@ -140,12 +142,18 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  max-height: 350px;
 }
 
 .media-item:hover {
   transform: scale(1.05);
   transition: transform 0.3s ease;
+}
+
+.news-media-gallery .media-item:only-child {
+  flex: 1 1 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  aspect-ratio: 4 / 3;
 }
 
 .news-links {

--- a/frontend/src/pages/News/styles/NewsSection.css
+++ b/frontend/src/pages/News/styles/NewsSection.css
@@ -52,8 +52,8 @@
 }
 
 .news-section-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); /* más chica la card */
   gap: var(--spacing-lg);
   max-width: 900px;
   margin: 0 auto;
@@ -100,7 +100,7 @@
 .news-section-image-wrapper {
   position: relative;
   width: 100%;
-  height: 240px;
+  aspect-ratio: 1 / 1; /* cuadrada */
   background: #ccc;
 }
 
@@ -133,12 +133,19 @@
 
 .news-section-title-overlay h2 {
   color: white;
-  font-size: var(--font-size-large);
+  font-size: var(--font-size-xl); /* más grande que antes */
+  font-weight: bold;
   margin: 0;
   transition: font-size 0.3s ease;
   text-shadow: 0 2px 4px rgba(0,0,0,0.8);
 }
 
 .news-section-item:hover .news-section-title-overlay h2 {
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-xxl); /* se agranda más en hover */
+}
+
+@media (max-width: 480px) {
+  .news-section-search-container {
+    width: 100%;
+  }
 }

--- a/frontend/src/pages/News/styles/NewsSection.css
+++ b/frontend/src/pages/News/styles/NewsSection.css
@@ -1,0 +1,144 @@
+.news-section-container {
+  padding: var(--spacing-xl) var(--spacing-md);
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.news-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-xl);
+  padding-bottom: var(--spacing-md);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.news-section-header h1 {
+  font-size: var(--font-size-xxl);
+  font-weight: 600;
+  margin: 0;
+}
+
+.news-section-actions {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.news-section-search-container {
+  position: relative;
+  width: 300px;
+}
+
+.news-section-search-input {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  padding-right: 40px;
+  border: 2px solid var(--border-color);
+  border-radius: var(--border-radius-md);
+}
+
+.news-section-search-input:focus {
+  border-color: var(--primary-color);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--primary-light);
+}
+
+.news-section-search-icon {
+  position: absolute;
+  right: var(--spacing-md);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-light);
+}
+
+.news-section-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.news-section-item {
+  background: var(--background-color);
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.news-section-item:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-lg);
+}
+
+.news-section-authors-bar {
+  display: flex;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm);
+  background: var(--secondary-background);
+}
+
+.news-section-author-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+
+.news-section-author-placeholder {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--primary-light);
+  color: var(--primary-dark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.news-section-image-wrapper {
+  position: relative;
+  width: 100%;
+  height: 240px;
+  background: #ccc;
+}
+
+.news-section-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.news-section-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e0e0e0;
+  color: #555;
+  height: 100%;
+}
+
+.news-section-placeholder-icon {
+  font-size: 48px;
+}
+
+.news-section-title-overlay {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  padding: var(--spacing-md);
+  background: linear-gradient(180deg, transparent, rgba(0,0,0,0.7));
+}
+
+.news-section-title-overlay h2 {
+  color: white;
+  font-size: var(--font-size-large);
+  margin: 0;
+  transition: font-size 0.3s ease;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.8);
+}
+
+.news-section-item:hover .news-section-title-overlay h2 {
+  font-size: var(--font-size-xl);
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -214,6 +214,27 @@ export interface CommentResponseDTO extends Comment {
   childrenCount?: number;
 }
 
+
+export interface News {
+  id: number;
+  title: string;
+  content: string;
+  createdAt: string;
+  authors: string[];
+  links: string[];
+  mediaLinks: MediaLink[];
+  previewImage: string;
+}
+
+export interface NewsDTO {
+  title: string;
+  content: string;
+  authors: string[];
+  links: string[];
+  mediaLinks: MediaLink[];
+  previewImage: string;
+}
+
 /**
  * Utility type for nullable values
  * @type Nullable


### PR DESCRIPTION
### 📌 Description

This PR implements the complete **News module** on the frontend, including both:

- ✅ **Admin panel features:**
  - Create, edit, delete news articles
  - Form validation and feedback
  - Preview image support
  - Integration with backend `/api/news` endpoints

- ✅ **Public display:**
  - Homepage integration for featured news
  - Visual layout styled like a newspaper
  - Responsive design for desktop and mobile
  - Styled headlines, preview images, and article snippets

### 🖼 Style

The public-facing section follows a minimalistic **newspaper aesthetic**, emphasizing:
- clean typography,
- strong article hierarchy (headlines, authors, preview image),
- and mobile readability.

### 🔗 Related
This feature integrates with the backend `NewsController` and uses DTOs for typed communication.